### PR TITLE
remplacer doGet par doPost pour conformer au principe REST

### DIFF
--- a/src/main/java/com/directmedia/onlinestore/backoffice/controller/AddWorkServlet.java
+++ b/src/main/java/com/directmedia/onlinestore/backoffice/controller/AddWorkServlet.java
@@ -33,7 +33,7 @@ public class AddWorkServlet extends HttpServlet {
      * @throws IOException if an I/O error occurs
      */
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         //Bien évidemment avant de fournir une réponse, il va fallor que l'on crée cette nouvelle oeuvre et 
         //  que l'on l'ajoute au catalogue. 


### PR DESCRIPTION
remplacer doGet par doPost pour conformer au principe REST